### PR TITLE
Improves check for valid repository names

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -101,9 +101,9 @@ class Settings implements SettingsInterface
     private function isValidRepositoryName($repository)
     {
         if (is_string($repository) === false
-            || strpos($repository, '/') === false
-            || strpos($repository, '/') === 0
             || substr_count($repository, '/') !== 1
+            || substr($repository, 0, 1) === '/'
+            || substr($repository, -1, 1) === '/'
         ) {
             $message = sprintf(
                 self::ERROR_INVALID_REPOSITORY_NAME,

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -226,6 +226,8 @@ class SettingsTest extends \PHPUnit_Framework_TestCase
             [array()],
             ['foo'],
             ['/foo'],
+            ['foo/'],
+            ['foo//bar'],
             ['foo/bar/'],
             ['/foo/bar/'],
             ['foo/bar/baz'],


### PR DESCRIPTION
- Adds test for repository names with a single slash that is also a trailing slash
- Adds test for repository names with two consecutive slashes
- Updates check that name is valid by not allowing names with a single trailing slash

Fixes #4
