### PR TITLE
Changes required PHP version to 5.4 for production as 5.5 syntax only applies to testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,13 @@
         }
     ],
     "require": {
-        "php" : ">=5.5",
+        "php" : ">=5.4",
         "knplabs/github-api": "^1.4",
         "league/flysystem": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^5.2.0",
+        "php" : ">=5.5",
+        "phpunit/phpunit" : "^4.7.7",
         "satooshi/php-coveralls": "^0.6.1",
         "scrutinizer/ocular": "^1.1",
         "whatthejeff/nyancat-phpunit-resultprinter": "^1.2"

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -53,8 +53,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             Client::class
         );
 
-        $this->expectException(\PHPUnit_Framework_Error::class);
-        $this->expectExceptionMessage($message);
+        $this->setExpectedException(\PHPUnit_Framework_Error::class, $message);
 
         /** @noinspection PhpParamsInspection */
         new Api();
@@ -72,8 +71,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             SettingsInterface::class
         );
 
-        $this->expectException(\PHPUnit_Framework_Error::class);
-        $this->expectExceptionMessage($message);
+        $this->setExpectedException(\PHPUnit_Framework_Error::class, $message);
 
         /** @noinspection PhpParamsInspection */
         new Api($this->getMockClient());
@@ -229,8 +227,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     {
         $api = $this->api;
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage(self::MOCK_FILE_CONTENTS);
+        $this->setExpectedException(RuntimeException::class, self::MOCK_FILE_CONTENTS);
 
         $expected = false;
 
@@ -250,8 +247,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     {
         $api = $this->api;
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(Api::ERROR_NOT_FOUND);
+        $this->setExpectedException(\RuntimeException::class, Api::ERROR_NOT_FOUND);
 
         $expected = false;
 


### PR DESCRIPTION
Fixes #9.
